### PR TITLE
Fix API base url in contact form

### DIFF
--- a/src/components/Contact/Contact.jsx
+++ b/src/components/Contact/Contact.jsx
@@ -3,6 +3,8 @@ import axios from "axios";
 import { toast } from "react-toastify";
 import { cn } from "../../lib/utils";
 
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5001";
+
 export default function MergedContactForm() {
   const initialFormState = {
     nombre: "",
@@ -56,7 +58,7 @@ export default function MergedContactForm() {
       setIsSubmitting(true);
       try {
         const response = await axios.post(
-          "http://localhost:5001/api/contact", // Actualizar puerto a 5001
+          `${API_URL}/api/contact`,
           formData,
           {
             withCredentials: true,


### PR DESCRIPTION
## Summary
- use VITE_API_URL in the standalone Contact form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b39c4b420832f8e564f3a808f451e